### PR TITLE
Highlight only non-widget views.

### DIFF
--- a/word_highlight.py
+++ b/word_highlight.py
@@ -37,7 +37,8 @@ class WordHighlightListener(sublime_plugin.EventListener):
 		Pref.word_separators = view.settings().get('word_separators')
 
 	def on_selection_modified(self, view):
-		self.pend_highlight_occurences(view)
+		if not view.settings().get('is_widget'):
+			self.pend_highlight_occurences(view)
 
 	@delayed(0.04)
 	def pend_highlight_occurences(self, view):


### PR DESCRIPTION
Hi - WordHighlight was causing the fields in panels to get incorrectly colored (e.g. I'm seeing black text in the search fields).  This was mostly apparent when draw_outlined is False.  See [here](http://www.sublimetext.com/forum/viewtopic.php?f=2&t=3685) for details.  This patch should fix the issue...
