### PR TITLE
Highlight delay is configured via settings file

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -35,6 +35,11 @@ Under the Packages/WordHighlight sub-directory, edit the `Word Highlight.sublime
 	This makes words highlight when the insertion point is inside of them but when
 	they're not actually selected.
 
+*	`"selection_delay" : 0.04`
+	
+	This delays highlighting all occurences using given time (in seconds) to let users move cursor 
+	around without being distracted with immediate highlights. Default value 0.04 means almost no delay.
+
 *	`"color_scope_name" : "wordhighlight"`
 	
 	Normally the color of the highlights is the same as the color of comments in

--- a/Word Highlight.sublime-settings
+++ b/Word Highlight.sublime-settings
@@ -1,5 +1,5 @@
 {
 	"draw_outlined": true,
-	"selection_delay": 0.5,
+	"selection_delay": 0.04,
 	"highlight_when_selection_is_empty": false
 }

--- a/word_highlight.py
+++ b/word_highlight.py
@@ -7,8 +7,8 @@ settings = sublime.load_settings('Word Highlight.sublime-settings')
 
 class Pref:
 	def load(self):
-		Pref.color_scope_name                 	= settings.get('color_scope_name', "comment")
-		Pref.selection_delay					= settings.get('selection_delay', 0.04)
+		Pref.color_scope_name               	= settings.get('color_scope_name', "comment")
+		Pref.selection_delay                    = settings.get('selection_delay', 0.04)
 		Pref.draw_outlined                    	= bool(settings.get('draw_outlined', True)) * sublime.DRAW_OUTLINED
 		Pref.highlight_when_selection_is_empty	= bool(settings.get('highlight_when_selection_is_empty', True))
 		Pref.word_separators                  	= []


### PR DESCRIPTION
If no "selection_delay" config key is present, default internal value 0.04 sec is used, which makes selection almost immediate. Currently config file contains value set to 0.5 sec as default to let users move cursor around without being distracted with immediate highlights. This time is similar to one used by eclipse in its "mark occurences" feature.
