### PR TITLE
Prevent alt+enter hotkey from breaking find dialog when it contains selected text

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,5 +1,7 @@
 [
 	{ "keys": ["alt+enter"], "command": "select_highlighted_words", "context":
-		[ { "key": "selection_empty", "operator": "equal", "operand": false } ]
+		[	{ "key": "selection_empty", "operator": "equal", "operand": false },
+			{ "key": "setting.is_widget", "operator": "equal", "operand": false }
+		]
 	}
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,5 +1,7 @@
 [
 	{ "keys": ["alt+enter"], "command": "select_highlighted_words", "context":
-		[ { "key": "selection_empty", "operator": "equal", "operand": false } ]
+		[	{ "key": "selection_empty", "operator": "equal", "operand": false },
+			{ "key": "setting.is_widget", "operator": "equal", "operand": false }
+		]
 	}
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,5 +1,7 @@
 [
 	{ "keys": ["alt+enter"], "command": "select_highlighted_words", "context":
-		[ { "key": "selection_empty", "operator": "equal", "operand": false } ]
+		[	{ "key": "selection_empty", "operator": "equal", "operand": false },
+			{ "key": "setting.is_widget", "operator": "equal", "operand": false }
+		]
 	}
 ]


### PR DESCRIPTION
Prevent alt+enter hotkey from breaking find dialog when it contains selected text.  See http://www.sublimetext.com/forum/viewtopic.php?f=2&t=5452
