### PR TITLE
Sublime 3 compatibility

### DIFF
--- a/word_highlight.py
+++ b/word_highlight.py
@@ -7,13 +7,14 @@ import sublime_plugin
 
 
 def plugin_loaded():
+	global settings_base
+	global Pref
+
 	settings = sublime.load_settings('Word Highlight.sublime-settings')
 	if int(sublime.version()) >= 2174:
 		settings_base = sublime.load_settings('Preferences.sublime-settings')
 	else:
 		settings_base = sublime.load_settings('Base File.sublime-settings')
-
-	global Pref
 
 	class Pref:
 		def load(self):


### PR DESCRIPTION
A quick pass at Sublime 3 compatibility, requires build 3009+ (for plugin_loaded callback support)
