### PR TITLE
Limit length of the status bar message

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -65,6 +65,10 @@ Under the Packages/WordHighlight sub-directory, edit the `Word Highlight.sublime
 	This lets you toggle if you want a status bar message to show how many occurrences of the highlighted word there are.
 	If you mix this with `"highlight_word_under_cursor_when_selection_is_empty": false` the occurrence number will not count word your cursor is on.
 
+*	`"show_word_highlight_status_bar_message_length" : 200`
+
+	This lets you limit the length of the status bar message to prevent it from using the whole of status bar which might hide other messages.
+
 *	`"color_scope_name" : "wordhighlight"`
 
 	Normally the color of the highlights is the same as the color of comments in

--- a/word_highlight.py
+++ b/word_highlight.py
@@ -36,6 +36,7 @@ def plugin_loaded():
 			Pref.highlight_non_word_characters                       = bool(settings.get('highlight_non_word_characters', False))
 			Pref.word_separators                                     = settings_base.get('word_separators')
 			Pref.show_status_bar_message                             = bool(settings.get('show_word_highlight_status_bar_message', True))
+			Pref.status_bar_message_max_len                          = settings.get('show_word_highlight_status_bar_message_length', 200)
 			Pref.file_size_limit                                     = int(settings.get('file_size_limit', 4194304))
 			Pref.when_file_size_limit_search_this_num_of_characters  = int(settings.get('when_file_size_limit_search_this_num_of_characters', 20000))
 			Pref.timing                                              = time.time()
@@ -140,6 +141,8 @@ class WordHighlightListener(sublime_plugin.EventListener):
 
 	def set_status(self, view, message):
 		if Pref.show_status_bar_message:
+			if len(message) > (Pref.status_bar_message_max_len-3):
+				message = message[:Pref.status_bar_message_max_len-3] + '..."'
 			view.set_status("WordHighlight", message)
 
 	def highlight_occurences(self, view):


### PR DESCRIPTION
Prevent status bar message from using the whole of status bar which might hide other messages.