### PR TITLE
Add highlight_on_multiple_selections and highlight_on_multiline_selec…

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -55,6 +55,12 @@ Under the Packages/WordHighlight sub-directory, edit the `Word Highlight.sublime
 
 	When the previous option is enabled, this makes the word under the cursor to gain highlighting
 
+*	`"minimum_characters" : 1`
+
+	The minimum number of characters a selection must contain before occurrences are highlighted.
+	Increase this to avoid highlighting noise from short selections. Default value 1 means any
+	non-empty selection triggers highlighting.
+
 *	`"highlight_delay" : 0`
 
 	This delays highlighting all occurrences using given time (in milliseconds) to let users move cursor

--- a/README.markdown
+++ b/README.markdown
@@ -99,6 +99,14 @@ Under the Packages/WordHighlight sub-directory, edit the `Word Highlight.sublime
 	of your tmTheme and add their own modifications, and if you are using a plugin that
 	does this, your change to the `.tmTheme` file may not be reflected in the UI immediately.
 
+*	`"highlight_on_multiple_selections" : true`
+
+	When set to false, disables highlighting when there are multiple cursors or selections active.
+
+*	`"highlight_on_multiline_selection" : true`
+
+	When set to false, disables highlighting when the selection spans more than one line.
+
 * `"file_size_limit" : 4194304`
 
 	Files bigger than this number will put WordHighlight on mode "highlight around view port" (a portion of the document)

--- a/Word Highlight.sublime-settings
+++ b/Word Highlight.sublime-settings
@@ -13,6 +13,8 @@
 	"highlight_when_selection_is_empty": false,
 	"highlight_word_under_cursor_when_selection_is_empty": false,
 	"highlight_non_word_characters": false,
+	"highlight_on_multiple_selections": true,
+	"highlight_on_multiline_selection": true,
 
 	"file_size_limit": 4194304,
 	"when_file_size_limit_search_this_num_of_characters": 20000

--- a/Word Highlight.sublime-settings
+++ b/Word Highlight.sublime-settings
@@ -9,6 +9,7 @@
 	// valid types: dot, circle, bookmark and cross
 	"icon_type_on_gutter" : "dot",
 
+	"minimum_characters": 1,
 	"highlight_delay": 0,
 	"highlight_when_selection_is_empty": false,
 	"highlight_word_under_cursor_when_selection_is_empty": false,

--- a/word_highlight.py
+++ b/word_highlight.py
@@ -34,6 +34,8 @@ def plugin_loaded():
 			Pref.highlight_when_selection_is_empty                   = bool(settings.get('highlight_when_selection_is_empty', False))
 			Pref.highlight_word_under_cursor_when_selection_is_empty = bool(settings.get('highlight_word_under_cursor_when_selection_is_empty', False))
 			Pref.highlight_non_word_characters                       = bool(settings.get('highlight_non_word_characters', False))
+			Pref.highlight_on_multiple_selections                    = bool(settings.get('highlight_on_multiple_selections', True))
+			Pref.highlight_on_multiline_selection                    = bool(settings.get('highlight_on_multiline_selection', True))
 			Pref.word_separators                                     = settings_base.get('word_separators')
 			Pref.show_status_bar_message                             = bool(settings.get('show_word_highlight_status_bar_message', True))
 			Pref.status_bar_message_max_len                          = settings.get('show_word_highlight_status_bar_message_length', 200)
@@ -180,6 +182,18 @@ class WordHighlightListener(sublime_plugin.EventListener):
 			view.set_status("WordHighlight", message)
 
 	def highlight_occurences(self, view, forceUpdate=False):
+		if not Pref.highlight_on_multiline_selection and any(view.rowcol(s.begin())[0] != view.rowcol(s.end())[0] for s in view.sel()):
+			view.erase_status("WordHighlight")
+			view.erase_regions("WordHighlight")
+			Pref.prev_regions = None
+			Pref.prev_selections = None
+			return
+		if not Pref.highlight_on_multiple_selections and len(list(view.sel())) > 1:
+			view.erase_status("WordHighlight")
+			view.erase_regions("WordHighlight")
+			Pref.prev_regions = None
+			Pref.prev_selections = None
+			return
 		if not Pref.highlight_when_selection_is_empty and not view.has_non_empty_selection_region():
 			view.erase_status("WordHighlight")
 			view.erase_regions("WordHighlight")

--- a/word_highlight.py
+++ b/word_highlight.py
@@ -42,6 +42,7 @@ def plugin_loaded():
 			Pref.file_size_limit                                     = int(settings.get('file_size_limit', 4194304))
 			Pref.when_file_size_limit_search_this_num_of_characters  = int(settings.get('when_file_size_limit_search_this_num_of_characters', 20000))
 			Pref.timing                                              = time.time()
+			Pref.minimum_characters                                  = int(settings.get('minimum_characters', 1))
 			Pref.enabled                                             = bool(settings.get('enabled', True))
 			Pref.prev_selections                                     = None
 			Pref.prev_regions                                        = None
@@ -223,14 +224,14 @@ class WordHighlightListener(sublime_plugin.EventListener):
 				string = view.substr(view.word(sel)).strip()
 				if string not in processedWords:
 					processedWords.append(string)
-					if string and all([not c in Pref.word_separators for c in string]):
+					if string and len(string) >= Pref.minimum_characters and all([not c in Pref.word_separators for c in string]):
 							regions = self.find_regions(view, regions, string, limited_size)
 					if not Pref.highlight_word_under_cursor_when_selection_is_empty:
 						for s in view.sel():
 							regions = [r for r in regions if not r.contains(s)]
 			elif not sel.empty() and Pref.highlight_non_word_characters:
 				string = view.substr(sel)
-				if string and string not in processedWords:
+				if string and len(string) >= Pref.minimum_characters and string not in processedWords:
 					processedWords.append(string)
 					regions = self.find_regions(view, regions, string, limited_size)
 			elif not sel.empty():
@@ -239,7 +240,7 @@ class WordHighlightListener(sublime_plugin.EventListener):
 					string = view.substr(word).strip()
 					if string not in processedWords:
 						processedWords.append(string)
-						if string and all([not c in Pref.word_separators for c in string]):
+						if string and len(string) >= Pref.minimum_characters and all([not c in Pref.word_separators for c in string]):
 								regions = self.find_regions(view, regions, string, limited_size)
 
 			occurrences = len(regions)-occurrencesCount;


### PR DESCRIPTION
Adds configuration options to prevent the plugin from working on multiple selections (multiple cursors) and multi-line selections and an option to set the minimum number of characters needed to be selected for the plugin to work. 